### PR TITLE
Added Plantish list in carouselView, love the challenge <3

### DIFF
--- a/CarouselViewChallenge/CarouselViewChallenge/App.xaml
+++ b/CarouselViewChallenge/CarouselViewChallenge/App.xaml
@@ -6,5 +6,8 @@
              mc:Ignorable="d"
              x:Class="CarouselViewChallenge.App">
     <Application.Resources>
+        <Color x:Key="MainAppColor">#6B734F</Color>
+        <Color x:Key="LightAppColor">#B4BFA3</Color>
+        <Color x:Key="RedAppColor">#814131</Color>
     </Application.Resources>
 </Application>

--- a/CarouselViewChallenge/CarouselViewChallenge/CarouselViewChallenge.csproj
+++ b/CarouselViewChallenge/CarouselViewChallenge/CarouselViewChallenge.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -11,10 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Models\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="Views\WelcomePage.xaml.cs">
       <DependentUpon>WelcomePage.xaml</DependentUpon>
     </Compile>
@@ -22,6 +18,9 @@
 
   <ItemGroup>
     <EmbeddedResource Update="Views\CarouselViewChallengePage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Views\PlantView.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/CarouselViewChallenge/CarouselViewChallenge/Models/Plant.cs
+++ b/CarouselViewChallenge/CarouselViewChallenge/Models/Plant.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace CarouselViewChallenge.Models
+{
+    public class Plant
+    {
+        public Plant(string name, int wateringFrequency, DateTime lastWateringDate, ImageSource imageUrl)
+        {
+            Name = name;
+            LastWateringDate = lastWateringDate;
+            WateringFrequency = wateringFrequency;
+            NextWatering = LastWateringDate.AddDays(WateringFrequency);
+            ImageUrl = imageUrl;
+        }
+
+        public DateTime LastWateringDate { get; }
+
+        public string Name { get; }
+
+        public ImageSource ImageUrl { get; }
+
+        public int WateringFrequency { get; }
+
+        public DateTime NextWatering { get; }
+    }
+}

--- a/CarouselViewChallenge/CarouselViewChallenge/Resources/Converters/DateRelativeToNowStringConverter.cs
+++ b/CarouselViewChallenge/CarouselViewChallenge/Resources/Converters/DateRelativeToNowStringConverter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Globalization;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace CarouselViewChallenge.Resources.Converters
+{
+    public class DateRelativeToNowStringConverter : IValueConverter, IMarkupExtension
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                throw new ArgumentException("Input can not be null");
+            }
+
+            if (!DateTime.TryParse(value.ToString(), out var dateInput))
+            {
+                throw new ArgumentException("Input needs to be of type DateTime");
+            }
+
+            var now = DateTime.Now;
+            var remaining = Math.Round((dateInput - now).TotalDays);
+            var format = "{0} day";
+            if (remaining > 1)
+            {
+                format += "(s)";
+            }
+            return remaining == 0 ? "Today" : $"{string.Format(format, remaining.ToString())}";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/CarouselViewChallenge/CarouselViewChallenge/Services/FakePlantService.cs
+++ b/CarouselViewChallenge/CarouselViewChallenge/Services/FakePlantService.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using CarouselViewChallenge.Models;
+
+namespace CarouselViewChallenge.Services {
+    public class FakePlantService : IPlantService {
+        public async Task<IList<Plant>> GetPlants()
+        {
+            await Task.Delay(2000); //Slowing it down
+            return new List<Plant>()
+            {
+                new Plant(
+                    "Purple Rose",
+                    1,
+                    DateTime.Now.AddDays(-2), 
+                    "https://ae01.alicdn.com/kf/HTB13kt_RVXXXXcSXXXXq6xXFXXXr/5d-diy-diamond-painting-flowers-purple-rose-diamond-painting-bloemen-diamond-embroidery-mosaic-flowers-painting-rhinestones.jpg_640x640.jpg"),
+                new Plant(
+                    "Ilex verticillata",
+                    14,
+                    DateTime.Now.AddDays(-7),
+                    "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQhKRG7kiMY9gihS8gSTfuASylMhyDJjr9h9I8mwEIwGIaDIHbUkw"),
+                new Plant(
+                    "Sanguinaria",
+                    7,
+                    DateTime.Now.AddDays(-2),
+                    "https://www.studyread.com/wp-content/uploads/2016/04/sanguinaria-300x252.jpg?ezimgfmt=ng:webp/ngcb1"),
+            new Plant("Lotus", 30, DateTime.Now.AddDays(-10), "https://images-na.ssl-images-amazon.com/images/I/51mUIhGuV1L._SX425_.jpg"),
+            new Plant(
+                    "Cactus",
+                    365,
+                    DateTime.Now.AddDays(-254),
+                    "https://cdn.shopify.com/s/files/1/2203/9263/products/Notocactus_magnificus_Balloon_Cactus_1.jpg?v=1532468983"),
+            new Plant(
+                    "Apple",
+                    30,
+                    DateTime.Now.AddDays(-15),
+                    "https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Malus_domestica_a1.jpg/220px-Malus_domestica_a1.jpg"),
+            new Plant(
+                    "Apocynum cannabinum",
+                    7,
+                    DateTime.Now.AddDays(-2),
+                    "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b5/Apocynum_cannabinum_6801.JPG/220px-Apocynum_cannabinum_6801.JPG"),
+            new Plant(
+                    "Almond",
+                    30,
+                    DateTime.Now.AddDays(-15),
+                    "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/Ametllesjuliol.jpg/220px-Ametllesjuliol.jpg"),
+            new Plant(
+                    "Fraxinus pennsylvanica",
+                    30,
+                    DateTime.Now.AddDays(-15),
+                    "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a2/Fraxinus_pensylvanica_a1.jpg/220px-Fraxinus_pensylvanica_a1.jpg"),
+            new Plant(
+                    "Acer negundo",
+                    7,
+                    DateTime.Now.AddDays(-2),
+                    "https://upload.wikimedia.org/wikipedia/commons/thumb/1/18/Acnegundo.jpg/220px-Acnegundo.jpg")
+            };
+        }
+    }
+}

--- a/CarouselViewChallenge/CarouselViewChallenge/Services/IPlantService.cs
+++ b/CarouselViewChallenge/CarouselViewChallenge/Services/IPlantService.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using CarouselViewChallenge.Models;
+
+namespace CarouselViewChallenge.Services {
+    public interface IPlantService
+    {
+        Task<IList<Plant>> GetPlants();
+    }
+}

--- a/CarouselViewChallenge/CarouselViewChallenge/ViewModels/PlantViewModel.cs
+++ b/CarouselViewChallenge/CarouselViewChallenge/ViewModels/PlantViewModel.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms;
+
+namespace CarouselViewChallenge.ViewModels
+{
+    public class PlantViewModel
+    {
+        public PlantViewModel(string name, int wateringFrequency, DateTime lastWateringDate, ImageSource imageSource)
+        {
+            Name = name;
+            WateringFrequency = wateringFrequency;
+            LastWateringDate = lastWateringDate;
+            ImageUrl = imageSource;
+            NextWatering = LastWateringDate.AddDays(WateringFrequency);
+        }
+
+        public DateTime LastWateringDate { get; }
+
+        public string Name { get; }
+
+        public ImageSource ImageUrl { get; }
+
+        public int WateringFrequency { get; }
+
+        public DateTime NextWatering { get; }
+
+        public bool IsOverdue => DateTime.Now > NextWatering;
+
+    }
+}

--- a/CarouselViewChallenge/CarouselViewChallenge/ViewModels/PlantsViewModel.cs
+++ b/CarouselViewChallenge/CarouselViewChallenge/ViewModels/PlantsViewModel.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using CarouselViewChallenge.Services;
+
+namespace CarouselViewChallenge.ViewModels
+{
+    public class PlantsViewModel
+    {
+        private readonly IPlantService m_plantService;
+
+        public PlantsViewModel(IPlantService plantService)
+        {
+            m_plantService = plantService;
+        }
+
+        public ObservableCollection<PlantViewModel> Plants { get; } = new ObservableCollection<PlantViewModel>();
+
+        public async Task Initialize()
+        {
+            var plants = await m_plantService.GetPlants();
+            foreach (var plant in plants)
+            {
+                Plants.Add(new PlantViewModel(plant.Name, plant.WateringFrequency, plant.LastWateringDate, plant.ImageUrl));
+            }
+        }
+    }
+}

--- a/CarouselViewChallenge/CarouselViewChallenge/Views/CarouselViewChallengePage.xaml
+++ b/CarouselViewChallenge/CarouselViewChallenge/Views/CarouselViewChallengePage.xaml
@@ -1,13 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0"
+      encoding="utf-8"?>
+<!-- I am using an old WPF trick to get intellisense for my viewmodels (blend datacontext), this is becaus there is no good way of getting it when you have a viewmodel with
+            a non-empty constructor. Using d:BindingContext is a hassle, because of having to new up everything. -->
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d"
-             x:Class="CarouselViewChallenge.Views.CarouselViewChallengePage">
-    <ContentPage.Content>
-        <StackLayout BackgroundColor="#cfd8dc">
-            <Label Text="You can use this page for the CarouselView Challenge!" HorizontalOptions="Center" VerticalOptions="CenterAndExpand"/>
-        </StackLayout>
-    </ContentPage.Content>
+             xmlns:ViewModels="clr-namespace:CarouselViewChallenge.ViewModels;assembly=CarouselViewChallenge"
+             mc:Ignorable="d dblend"
+             x:Class="CarouselViewChallenge.Views.CarouselViewChallengePage"
+             x:DataType="ViewModels:PlantsViewModel"
+             xmlns:dblend="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:Views="clr-namespace:CarouselViewChallenge.Views;assembly=CarouselViewChallenge"
+             dblend:DataContext="{dblend:DesignInstance ViewModels:PlantsViewModel}"
+             BackgroundColor="{StaticResource MainAppColor}">
+    <CarouselView ItemsSource="{Binding Plants}"
+                  PeekAreaInsets="115">
+        <CarouselView.ItemTemplate>
+            <DataTemplate x:DataType="ViewModels:PlantViewModel">
+                <Views:PlantView BindingContext="{Binding .}" />
+            </DataTemplate>
+        </CarouselView.ItemTemplate>
+    </CarouselView>
 </ContentPage>

--- a/CarouselViewChallenge/CarouselViewChallenge/Views/CarouselViewChallengePage.xaml.cs
+++ b/CarouselViewChallenge/CarouselViewChallenge/Views/CarouselViewChallengePage.xaml.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
+using CarouselViewChallenge.Services;
+using CarouselViewChallenge.ViewModels;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -12,9 +13,19 @@ namespace CarouselViewChallenge.Views
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class CarouselViewChallengePage : ContentPage
     {
+        private PlantsViewModel m_plantsViewModel;
+
         public CarouselViewChallengePage()
         {
             InitializeComponent();
+            //Poor mans dependency injection
+            BindingContext = m_plantsViewModel =  new PlantsViewModel(new FakePlantService());
+        }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            await m_plantsViewModel.Initialize();
         }
     }
 }

--- a/CarouselViewChallenge/CarouselViewChallenge/Views/PlantView.xaml
+++ b/CarouselViewChallenge/CarouselViewChallenge/Views/PlantView.xaml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0"
+      encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d dblend"
+             x:Class="CarouselViewChallenge.Views.PlantView"
+             xmlns:ViewModels="clr-namespace:CarouselViewChallenge.ViewModels;assembly=CarouselViewChallenge"
+             x:DataType="ViewModels:PlantViewModel"
+             xmlns:dblend="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:Converters="clr-namespace:CarouselViewChallenge.Resources.Converters;assembly=CarouselViewChallenge"
+             dblend:DataContext="{dblend:DesignInstance ViewModels:PlantViewModel}">
+    <ContentView.Content>
+        <Grid VerticalOptions="CenterAndExpand"
+              HorizontalOptions="CenterAndExpand">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Frame Grid.Row="0"
+                   HeightRequest="250"
+                   WidthRequest="250"
+                   CornerRadius="125"
+                   HorizontalOptions="Center"
+                   VerticalOptions="Center"
+                   Padding="0"
+                   IsClippedToBounds="True">
+                <Image Aspect="AspectFill"
+                       Source="{Binding ImageUrl}" />
+            </Frame>
+            <StackLayout Grid.Row="1"
+                         HorizontalOptions="CenterAndExpand"
+                         Margin="25,0,0,0"
+            >
+                <Label Text="{Binding Name}"
+                       FontSize="Title" />
+                <StackLayout Orientation="Horizontal">
+                    <Label
+                        Text="{Binding NextWatering,Converter={Converters:DateRelativeToNowStringConverter}, StringFormat='Next watering in: {0}'}" 
+                        VerticalOptions="Center"/>
+                    <Frame HeightRequest="25"
+                           WidthRequest="25"
+                           CornerRadius="12.5"
+                           BackgroundColor="{StaticResource RedAppColor}"
+                           Padding="0"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center"
+                           IsVisible="{Binding IsOverdue}">
+                        <Label Text="!"
+                               HorizontalOptions="Center"
+                               VerticalOptions="Center"
+                               TextColor="White"
+                               FontAttributes="Bold" />
+                    </Frame></StackLayout>
+            </StackLayout>
+        </Grid>
+    </ContentView.Content>
+</ContentView>

--- a/CarouselViewChallenge/CarouselViewChallenge/Views/PlantView.xaml.cs
+++ b/CarouselViewChallenge/CarouselViewChallenge/Views/PlantView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace CarouselViewChallenge.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class PlantView : ContentView
+    {
+        public PlantView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Submission description
I implemented a list of plants that should display if a plant needs watering. This idea is from my app [Plantish](https://github.com/haavamoa/Plantish). I have not settled on how the actual watering part should be displayed, but here is a hardcoded list of plants and a simple indication that it needs watering.

![Plantish](https://user-images.githubusercontent.com/2527084/64758824-e0064100-d535-11e9-9f1c-f484e9bfb88a.gif)


### What went well

This was a pretty straight forward experience for me. I have never used it before, but it was really easy to understand how to implement it. I am a big fan of having the item templates in a separate file, and I appreciate that I can do this here as well.

### What didn't go well

I did not have any issues with using the CarouselView, but I had a couple of issues with Xaml Hot Reloading and the `CarouselView`:
   - "LoadDataTemplate should not be null exception" when Hot Reloading and having a blank `DataTemplate` (happened at the start of the project when starting on the `CarouselView`).
- If I have enabled Hot Reloading and are changing the first item, it reloads. If I swipe to the next item and do the change, it fails :
        "Unable to Active instance of Type Xamarin.Forms.Android.FastRenderers.LabelRenderer .."
    

### Missing or desired things

It would be really nice to have a property on the `CarouselView` where I can turn on indications of where in the stack you are right now. I believe that I have seen dots at the bottom of the `CarouselView` as a way of indicating this.
